### PR TITLE
feat: add option to exclude argocd apps by paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           argocd-version: v2.2.5
           argocd-extra-cli-args: --grpc-web
-          argocd-exclude-paths: "do-dev-1/faas-functions,"
+          argocd-exclude-paths: "path/to/exclude,"
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - uses: quizlet/argocd-diff-action@master
+      - uses: ratehub/argocd-diff-action@master
         name: ArgoCD Diff
         with:
           argocd-server-url: argocd.example.com
           argocd-token: ${{ secrets.ARGOCD_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          argocd-version: v1.6.1
+          argocd-version: v2.2.5
           argocd-extra-cli-args: --grpc-web
+          argocd-exclude-paths: "do-dev-1/faas-functions,"
 ```
 
 ## How it works

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Extra arguments to pass to the argocd CLI
     default: --grpc-web
     required: false
+  argocd-exclude-paths: 
+    description: ArgoCD app apths to exclude in comma separated list
+    default: ''
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1755,11 +1755,11 @@ function getApps() {
             core.error(e);
         }
         return responseJson.items.filter(app => {
-            return (app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`)
+            return app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`
                 && (app.spec.source.targetRevision === 'master'
                     || app.spec.source.targetRevision === 'main'
                     || app.spec.source.targetRevision === 'HEAD')
-                && (!EXCLUDE_PATHS.includes(app.spec.source.path)));
+                && !EXCLUDE_PATHS.includes(app.spec.source.path));
         });
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1698,6 +1698,7 @@ const ARGOCD_SERVER_URL = core.getInput('argocd-server-url');
 const ARGOCD_TOKEN = core.getInput('argocd-token');
 const VERSION = core.getInput('argocd-version');
 const EXTRA_CLI_ARGS = core.getInput('argocd-extra-cli-args');
+const EXCLUDE_PATHS = core.getInput('argocd-exclude-paths').split(',');
 const octokit = github.getOctokit(githubToken);
 function execCommand(command, options = {}) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1754,7 +1755,11 @@ function getApps() {
             core.error(e);
         }
         return responseJson.items.filter(app => {
-            return (app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`) && (app.spec.source.targetRevision === 'master' || app.spec.source.targetRevision === 'main' || app.spec.source.targetRevision === 'HEAD'));
+            return (app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`)
+                && (app.spec.source.targetRevision === 'master'
+                    || app.spec.source.targetRevision === 'main'
+                    || app.spec.source.targetRevision === 'HEAD')
+                && (!EXCLUDE_PATHS.includes(app.spec.source.path)));
         });
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ async function getApps(): Promise<App[]> {
           app.spec.source.targetRevision === 'master'
           || app.spec.source.targetRevision === 'main'
           || app.spec.source.targetRevision === 'HEAD')
-      && (!EXCLUDE_PATHS.includes(app.spec.source.path))
+      && !EXCLUDE_PATHS.includes(app.spec.source.path)
     );
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ const ARGOCD_SERVER_URL = core.getInput('argocd-server-url');
 const ARGOCD_TOKEN = core.getInput('argocd-token');
 const VERSION = core.getInput('argocd-version');
 const EXTRA_CLI_ARGS = core.getInput('argocd-extra-cli-args');
-
+const EXCLUDE_PATHS = core.getInput('argocd-exclude-paths').split(',');
 const octokit = github.getOctokit(githubToken);
 
 async function execCommand(command: string, options: ExecOptions = {}): Promise<ExecResult> {
@@ -100,9 +100,12 @@ async function getApps(): Promise<App[]> {
 
   return (responseJson.items as App[]).filter(app => {
     return (
-      app.spec.source.repoURL.includes(
-        `${github.context.repo.owner}/${github.context.repo.repo}`
-      ) && (app.spec.source.targetRevision === 'master' || app.spec.source.targetRevision === 'main' || app.spec.source.targetRevision === 'HEAD')
+      app.spec.source.repoURL.includes(`${github.context.repo.owner}/${github.context.repo.repo}`)
+      && (
+          app.spec.source.targetRevision === 'master'
+          || app.spec.source.targetRevision === 'main'
+          || app.spec.source.targetRevision === 'HEAD')
+      && (!EXCLUDE_PATHS.includes(app.spec.source.path))
     );
   });
 }


### PR DESCRIPTION
Add an option to the action to exclude ArgoCD apps by app `path`.

Fixes [issue found in this workflow run](https://github.com/ratehub/ratehub-k8s/runs/5426460452?check_suite_focus=true#step:3:12455) for https://github.com/ratehub/ratehub-k8s/pull/704.